### PR TITLE
Intermediate Interface

### DIFF
--- a/ir/AdminQAPI.h
+++ b/ir/AdminQAPI.h
@@ -1,0 +1,20 @@
+#include "AdminQLog.h"
+#include "AdminQHeader.h"
+#include "stdio.h"
+
+/* ---------------- GLOBAL SHARED INTERFACE ---------------- */
+
+/* Standard Accessor Interface for Internal Functions */
+
+/* The version of the i40e AdminQ API definition being used*/
+uint32_t API_VERSION;
+
+/* Error Code Definition Access */
+Errors* ERRORS;
+
+/* Command Definition Access */
+Commands* COMMANDS;
+
+/* Retrieves a in-order representation of AdminQ entries within this log file */
+Entry** parse(FILE* log);
+

--- a/ir/AdminQAPI.h
+++ b/ir/AdminQAPI.h
@@ -1,6 +1,9 @@
+#ifndef ADMINQ_IR_MAIN_H
+#define ADMINQ_IR_MAIN_H
+
+#include <stdio.h>
 #include "AdminQLog.h"
 #include "AdminQHeader.h"
-#include "stdio.h"
 
 /* ---------------- GLOBAL SHARED INTERFACE ---------------- */
 
@@ -10,11 +13,14 @@
 uint32_t API_VERSION;
 
 /* Error Code Definition Access */
-Errors* ERRORS;
+Errors *ERRORS;
 
 /* Command Definition Access */
-Commands* COMMANDS;
+Commands *COMMANDS;
 
 /* Retrieves a in-order representation of AdminQ entries within this log file */
-Entry** parse(FILE* log);
+Entry **parse(FILE *log);
+
+#endif /* ADMINQ_IR_MAIN_H */
+
 

--- a/ir/AdminQHeader.h
+++ b/ir/AdminQHeader.h
@@ -1,25 +1,50 @@
+#ifndef ADMINQ_IR_HEADER_H
+#define ADMINQ_IR_HEADER_H
+
+#include <stdio.h>
+
 /* ---------------- HEADER API DEFINITION FILE PARSER SECTION ---------------- */
 
 /* Available Error Codes */
 typedef struct {
-	char* fromByte(uint16_t val); /* A String representation of the corresponding error code - or ERR_UNKNOWN if not defined */
+    char *fromByte(uint16_t val); /* A String representation of the corresponding error code - or ERR_UNKNOWN if not defined */
 } Errors;
 
 /* Available AdminQ Commands */
 typedef struct {
-	AdminQCommand* fromByte(uint16_t opcode); /* Returns the command definition corresponding to that opcode */
+    AdminQCommand *fromByte(uint16_t opcode); /* Returns the command definition corresponding to that opcode */
 } Commands;
+
+/* A field within a command definition */
+typedef struct Field Field;
+
+/* Table Node */
+typedef struct Table Table;
 
 /* A Command Definition Derived From the API Header File*/
 typedef struct {
-	char* name; /* The name of the command (corresponds to its key within the OpCode enum) */
-	char* flagFromByte(uint16_t flags); /* A string representation of the flag value for this command - can be NULL */
-	Map<char*, Field> fieldsFromByte(uint16_t buflen, uint8_t* buf); /*  A mapping of field name -> field value from the provided (direct or indirect) data buffer */
+    char *name; /* The name of the command (corresponds to its key within the OpCode enum) */
+    char *flagFromByte(uint16_t flags); /* A string representation of the flag value for this command - can be NULL */
+    Table *fieldsFromByte(uint16_t buflen,uint8_t *buf); /*  A mapping of field name -> field value from the provided (direct or indirect) data buffer */
 } AdminQCommand;
 
 /* A field within a command definition */
-typedef struct {
-	char* value; /* A string representation of the value: could be raw bytes, or a corresponding #define if available */
-	int startpos; /* The starting position within the byte buffer corresponding to this value (might be useful for highlighting) */
-	int endpos; /* The ending position within the byte buffer corresponding to this value */
-} Field;
+struct Field {
+    char *value; /* A string representation of the value: could be raw bytes, or a corresponding #define if available */
+    int startpos; /* The starting position within the byte buffer corresponding to this value (might be useful for highlighting) */
+    int endpos; /* The ending position within the byte buffer corresponding to this value */
+};
+
+/* A linear field->value table node */
+struct Table {
+    Table *next;
+    char *fieldName;
+    Field *fieldVal;
+    Table *last;
+
+    void init(char *field, Field *val);
+    void insert(char *field, Field *val);
+};
+
+#endif /* ADMINQ_IR_HEADER_H */
+

--- a/ir/AdminQHeader.h
+++ b/ir/AdminQHeader.h
@@ -1,25 +1,25 @@
 /* ---------------- HEADER API DEFINITION FILE PARSER SECTION ---------------- */
 
 /* Available Error Codes */
-class Errors {
+typedef struct {
 	char* fromByte(uint16_t val); /* A String representation of the corresponding error code - or ERR_UNKNOWN if not defined */
-};
+} Errors;
 
 /* Available AdminQ Commands */
-class Opcodes {
+typedef struct {
 	AdminQCommand* fromByte(uint16_t opcode); /* Returns the command definition corresponding to that opcode */
-};
+} Commands;
 
 /* A Command Definition Derived From the API Header File*/
-class AdminQCommand {
+typedef struct {
 	char* name; /* The name of the command (corresponds to its key within the OpCode enum) */
 	char* flagFromByte(uint16_t flags); /* A string representation of the flag value for this command - can be NULL */
 	Map<char*, Field> fieldsFromByte(uint16_t buflen, uint8_t* buf); /*  A mapping of field name -> field value from the provided (direct or indirect) data buffer */
-};
+} AdminQCommand;
 
 /* A field within a command definition */
-class Field {
+typedef struct {
 	char* value; /* A string representation of the value: could be raw bytes, or a corresponding #define if available */
 	int startpos; /* The starting position within the byte buffer corresponding to this value (might be useful for highlighting) */
 	int endpos; /* The ending position within the byte buffer corresponding to this value */
-};
+} Field;

--- a/ir/AdminQHeader.h
+++ b/ir/AdminQHeader.h
@@ -1,0 +1,25 @@
+/* ---------------- HEADER API DEFINITION FILE PARSER SECTION ---------------- */
+
+/* Available Error Codes */
+class Errors {
+	char* fromByte(uint16_t val); /* A String representation of the corresponding error code - or ERR_UNKNOWN if not defined */
+};
+
+/* Available AdminQ Commands */
+class Opcodes {
+	AdminQCommand* fromByte(uint16_t opcode); /* Returns the command definition corresponding to that opcode */
+};
+
+/* A Command Definition Derived From the API Header File*/
+class AdminQCommand {
+	char* name; /* The name of the command (corresponds to its key within the OpCode enum) */
+	char* flagFromByte(uint16_t flags); /* A string representation of the flag value for this command - can be NULL */
+	Map<char*, Field> fieldsFromByte(uint16_t buflen, uint8_t* buf); /*  A mapping of field name -> field value from the provided (direct or indirect) data buffer */
+};
+
+/* A field within a command definition */
+class Field {
+	char* value; /* A string representation of the value: could be raw bytes, or a corresponding #define if available */
+	int startpos; /* The starting position within the byte buffer corresponding to this value (might be useful for highlighting) */
+	int endpos; /* The ending position within the byte buffer corresponding to this value */
+};

--- a/ir/AdminQLog.h
+++ b/ir/AdminQLog.h
@@ -1,7 +1,7 @@
 /* ---------------- LOG PARSER SECTION ---------------- */
 
 /* Represents a single parsed entry within the log */
-class Entry {
+typedef struct {
     /* Main Command Fields (bytes 0-15) */
 	uint16_t flags;
 	uint16_t opcode;
@@ -12,4 +12,4 @@ class Entry {
 	/* Buffer Related Fields : can either be direct or indirect buffer */
 	uint16_t buflen;
 	uint8_t* buf;
-};
+} Entry;

--- a/ir/AdminQLog.h
+++ b/ir/AdminQLog.h
@@ -1,15 +1,22 @@
+#ifndef ADMINQ_IR_LOG_H
+#define ADMINQ_IR_LOG_H
+
+#include <stdio.h>
+
 /* ---------------- LOG PARSER SECTION ---------------- */
 
 /* Represents a single parsed entry within the log */
 typedef struct {
     /* Main Command Fields (bytes 0-15) */
-	uint16_t flags;
-	uint16_t opcode;
-	uint16_t retval;
-	uint32_t cookie_high;
-	uint32_t cookie_low;
+    uint16_t flags;
+    uint16_t opcode;
+    uint16_t retval;
+    uint32_t cookie_high;
+    uint32_t cookie_low;
 
-	/* Buffer Related Fields : can either be direct or indirect buffer */
-	uint16_t buflen;
-	uint8_t* buf;
+    /* Buffer Related Fields : can either be direct or indirect buffer */
+    uint16_t buflen;
+    uint8_t *buf;
 } Entry;
+
+#endif /* ADMINQ_IR_LOG_H */

--- a/ir/AdminQLog.h
+++ b/ir/AdminQLog.h
@@ -1,0 +1,15 @@
+/* ---------------- LOG PARSER SECTION ---------------- */
+
+/* Represents a single parsed entry within the log */
+class Entry {
+    /* Main Command Fields (bytes 0-15) */
+	uint16_t flags;
+	uint16_t opcode;
+	uint16_t retval;
+	uint32_t cookie_high;
+	uint32_t cookie_low;
+
+	/* Buffer Related Fields : can either be direct or indirect buffer */
+	uint16_t buflen;
+	uint8_t* buf;
+};

--- a/parsers/header/Table.c
+++ b/parsers/header/Table.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include "../../ir/AdminQHeader.h"
+
+void Table::init(char *field, Field *val) {
+    fieldName = field;
+    fieldVal = val;
+    next = NULL;
+    last = this;
+}
+
+void Table::insert(char *field, Field *val) {
+    /* The assumption is made that all operations will be done on the root node */
+    last->next = malloc(sizeof(Table));
+    last = last->next;
+    last->init(field, val);
+}
+


### PR DESCRIPTION
This is a proposal for intermediate header files so as to allow the various parts of the project (plugin/parser mainly) to begin work on components that rely on other sections as was outlined in [ICP-9](http://chimera.kingdomsofarden.net/browse/ICP-9) without requiring that all the code for that other sections be finished first.

This also simplifies testing as you can simply create mock objects to return to these API calls rather than generating a whole textual log file to test.

Finally, it should be noted that this is in no way intended to be complete: rather it only really supports several base features I thought would be mandatory for an initial release, and can be further expanded upon in the future (and on further note, will probably need to be checked for c syntax, since at the moment it can't be compiled anyways due to the reference to an unimplemented map structure). 

There are three files in this PR: 

```
AdminQAPI.h - A header file that defines various accessor fields that can be used to access
information within log files/api definition header file. It also provides an entry point to the 
parser that converts an input log file to a computational form.

AdminQLog.h - A single struct representation of a log entry along with raw buffer: information
can be extracted from this and sent to the parsed header representation

AdminQHeader.h - Structs that are used to represent information within the adminq command 
definition. Notably, bytes obtained from the Entry struct in AdminQLog can be used to convert 
to a string for display purposes
```

=== Feature Support === 
As of the first iteration, the target featureset (at least for myself, subject to change after more discussion) for this PR is the following:
- Ability to take an input log file and get the raw commands (termed Entry) as a sequence
  Which  should provide the information to do the following (for a single entry):
- Ability to load/print out what command is being run based on opcode
- Ability to print out any error return codes if non-0
- Ability to provide some basic analysis of any additional data: namely field names (stuff beyond the first 16 bytes) and their raw values. 
  - The capability to interpret those values and print out the interpreted versions (as defined using #defines) would fall under something I would personally put at the second iteration
